### PR TITLE
ASSIJUS: GOVSP: Parametrização do Assijus para comportamento rodando fora do TRF2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2</groupId>
 	<artifactId>assijus</artifactId>
 	<packaging>war</packaging>
-	<version>4.0.3</version>
+	<version>4.0.4</version>
 	<name>Assijus Maven Webapp</name>
 	<url>http://maven.apache.org</url>
 
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.crivano.blucservice</groupId>
 			<artifactId>blucservice-api</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.crivano</groupId>

--- a/src/main/java/br/jus/trf2/assijus/AssijusServlet.java
+++ b/src/main/java/br/jus/trf2/assijus/AssijusServlet.java
@@ -32,7 +32,10 @@ public class AssijusServlet extends SwaggerServlet {
 		addPublicProperty("systems", null);
 		addPublicProperty("popup.urls", "http://localhost:8080");
 		addRestrictedProperty("blucservice.url", "http://localhost:8080/blucservice/api/v1");
-
+		addPublicProperty("siga.url", "http://siga.jfrj.jus.br");
+		addPublicProperty("dotnet.download.url", "http://assijus.jfrj.jus.br/downloads/Microsoft-DOT-NET-Framework-x86-x64-AllOS-ENU.exe");
+		addPublicProperty("exibe.titulo.dr", "true");
+		
 		// Redis
 		//
 		addRestrictedProperty("redis.database", "10");

--- a/src/main/webapp/popup-api.js
+++ b/src/main/webapp/popup-api.js
@@ -1,4 +1,4 @@
-var frameSrc = "https://assijus.trf2.jus.br/assijus/popup.html";
+var frameSrc = "/assijus/popup.html";
 
 function receiveMessageAssinaturaDigital(event) {
 	var iframe = document.getElementById('iframeAssinaturaDigital');

--- a/src/main/webapp/popup.html
+++ b/src/main/webapp/popup.html
@@ -133,11 +133,11 @@
 							assinar documentos, pode ser necessário instalar o driver do
 							token e a cadeia de certificados da autoridade certificadora. O
 							procedimento de instalação é mesmo que consta da <a
-							href="http://siga.jfrj.jus.br">página de acesso externo do
+							id="linkAcessoSiga" href="{{sigaUrl}}">página de acesso externo do
 								SIGA</a>.
 						</li>
 						<li>Em Windows, instale <a
-							href="http://assijus.jfrj.jus.br/downloads/Microsoft-DOT-NET-Framework-x86-x64-AllOS-ENU.exe"><u>Microsoft
+							href="{{dotNetUrl}}"><u>Microsoft
 									.NET Framework 4.5.1</u></a>. Depois, instale o programa <a
 							href="signer/chrome-extension/assijus-chrome-extension-setup.msi"><u>assijus-chrome-extension-setup.msi</u></a>.
 						</li>

--- a/src/main/webapp/resources/app.js
+++ b/src/main/webapp/resources/app.js
@@ -179,8 +179,17 @@ app
 				});
 
 app.controller('ctrl2', function($scope, $http, $interval, $window) {
-
-
+	if ($scope.test.properties["assijus.siga.url"] !== undefined)	
+		$scope.sigaUrl =  $scope.test.properties["assijus.siga.url"]
+			.replace("[default: ", "")
+			.replace("]", "")
+			.replace("[undefined]", "");
+	
+	if ($scope.test.properties["assijus.dotnet.download.url"] !== undefined)	
+		$scope.dotNetUrl =  $scope.test.properties["assijus.dotnet.download.url"]
+			.replace("[default: ", "")
+			.replace("]", "")
+			.replace("[undefined]", "");			
 });
 
 app
@@ -1273,6 +1282,11 @@ app
 						// progressbar.
 						$scope.progress.start("Processando Login", 16, 0, 100);
 						$scope.testarSigner($scope.progress, $scope.login);
+					}
+					
+					$scope.apresentarTitulo = function() {
+						if ($scope.test.properties["assijus.exibe.titulo.dr"] !== undefined)
+							return $scope.test.properties["assijus.exibe.titulo.dr"].replace("[default: ", "").replace("]", "").replace("[undefined]", "") === "true";
 					}
 
 					if ($routeParams.logincallback) {

--- a/src/main/webapp/resources/home.html
+++ b/src/main/webapp/resources/home.html
@@ -110,7 +110,7 @@
 		<div class="row margin-bottom-30"
 			ng-show="zeroDocumentosCarregados() && assinanteIdentificado()">
 			<div class="col-md-12">
-				<p style="font-size: 120%;">Dr(a). {{assinante}}, não
+				<p style="font-size: 120%;"><span ng-show="apresentarTitulo()">Dr(a).</span> {{assinante}}, não
 					localizamos nenhum documento pendente de assinatura.</p>
 			</div>
 		</div>
@@ -123,7 +123,8 @@
 				</div>
 				<!-- 
 				<p style="font-size: 120%;"
-					ng-show="!apresentarProblema &amp;&amp; assinanteIdentificado() &amp;&amp; !zeroDocumentosCarregados()">Dr.
+					ng-show="!apresentarProblema &amp;&amp; assinanteIdentificado() &amp;&amp; !zeroDocumentosCarregados()">
+					<span ng-show="apresentarTitulo()">Dr.</span>
 					{{assinante}}, por favor, verifique os documentos abaixo e clique
 					em "Assinar".</p> -->
 			</div>

--- a/src/main/webapp/resources/sobre.html
+++ b/src/main/webapp/resources/sobre.html
@@ -24,12 +24,11 @@
 					<li>Caso o equipamento nunca tenha sido utilizado para assinar
 						documentos, pode ser necessário instalar o driver do token e a
 						cadeia de certificados da autoridade certificadora. O procedimento
-						de instalação é mesmo que consta da <a
-						href="http://siga.jfrj.jus.br">página de acesso externo do
-							SIGA</a>.
+						de instalação é mesmo que consta da 
+						<a id="linkAcessoSiga" href="{{sigaUrl}}">página de acesso externo do SIGA</a>.
 					</li>
 					<li>Em Windows, instale <a
-						href="http://assijus.jfrj.jus.br/downloads/Microsoft-DOT-NET-Framework-x86-x64-AllOS-ENU.exe"><u>Microsoft
+						href="{{dotNetUrl}}"><u>Microsoft
 								.NET Framework 4.5.1</u></a>. Depois, instale o programa <a
 						href="signer/chrome-extension/assijus-chrome-extension-setup.msi"><u>assijus-chrome-extension-setup.msi</u></a>.
 					</li>
@@ -55,7 +54,7 @@
 				</div>
 				<ol style="font-size: 120%;">
 					<li>Plugue seu token no computador e entre no site do <a
-						href="https://assijus.jfrj.jus.br"><u>Assijus</u></a>.
+						href="/assijus"><u>Assijus</u></a>.
 					</li>
 					<li>Escolha o certificado se houver mais de um e informe o PIN</li>
 					<li>Marque ou desmarque documentos para indicar quais devem


### PR DESCRIPTION
Criado uma parametrização básica para fazer o apontamento para os locais onde está rodando o SIGA e retirar a dependência de chamadas para o assijus do TRF2.

        "assijus.siga.url"
        "assijus.dotnet.download.url" 
        "assijus.exibe.titulo.dr" 