### PR TITLE
FIX: URL popup do assijus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.build.timestamp.format>dd/MM/yyyy HH:mm</maven.build.timestamp.format>
+		<assijus-url>https://assijus.jfrj.jus.br</assijus-url>
 	</properties>
 
 	<build>
@@ -89,6 +90,12 @@
 							<Build-Label>${project.version}</Build-Label>
 						</manifestEntries>
 					</archive>
+				  	<webResources>
+			            <resource>
+			                <directory>src/main/webapp</directory>
+			                <filtering>true</filtering>
+			            </resource>
+		         	</webResources>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2</groupId>
 	<artifactId>assijus</artifactId>
 	<packaging>war</packaging>
-	<version>4.0.4</version>
+	<version>4.0.5</version>
 	<name>Assijus Maven Webapp</name>
 	<url>http://maven.apache.org</url>
 

--- a/src/main/webapp/popup-api.js
+++ b/src/main/webapp/popup-api.js
@@ -1,4 +1,4 @@
-var frameSrc = "/assijus/popup.html";
+var frameSrc = "${assijus-url}/assijus/popup.html";
 
 function receiveMessageAssinaturaDigital(event) {
 	var iframe = document.getElementById('iframeAssinaturaDigital');


### PR DESCRIPTION
Em ambientes que o assijus roda em um domínio diferente do SIGA, não ficou viável usar o contexto relativo no popup-api.js.
Para resolver essa parametrização e evitar o hardcoded dos domínios foi criado um parâmetro no pom.xml "assijus-url". O default é a URL do assijus do TRF2, caso não seja sobrescrito no build do maven.

Para sobrescrever, como aqui em SP, basta acrescentar -Dassijus-url="XXXXX" no build.