### PR TITLE
Versão 4.1.1 - Correções gerais

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.dmg filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.dmg filter=lfs diff=lfs merge=lfs -text

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2</groupId>
 	<artifactId>assijus</artifactId>
 	<packaging>war</packaging>
-	<version>4.1.0</version>
+	<version>4.1.1</version>
 	<name>Assijus Maven Webapp</name>
 	<url>http://maven.apache.org</url>
 

--- a/src/main/java/br/jus/trf2/assijus/AssijusServlet.java
+++ b/src/main/java/br/jus/trf2/assijus/AssijusServlet.java
@@ -34,7 +34,7 @@ public class AssijusServlet extends SwaggerServlet {
 		addRestrictedProperty("blucservice.url", "http://localhost:8080/blucservice/api/v1");
 		addPublicProperty("siga.url", "http://siga.jfrj.jus.br");
 		addPublicProperty("dotnet.download.url", "http://assijus.jfrj.jus.br/downloads/Microsoft-DOT-NET-Framework-x86-x64-AllOS-ENU.exe");
-		addPublicProperty("java8.download.url", "resources/download/jdk-8u301-macosx-x64.dmg");
+		addPublicProperty("java8.download.url", "https://javadl.oracle.com/webapps/download/GetFile/1.8.0_301-b09/d3c52aa6bfa54d3ca74e617f18309292/unix-i586/jdk-8u301-macosx-x64.dmg");
 		addPublicProperty("exibe.titulo.dr", "true");
 		addPublicProperty("extensao.macos.version", "2.0.1");
 		addPublicProperty("extensao.windows.version", "1.2.10.6");

--- a/src/main/java/br/jus/trf2/assijus/AssijusServlet.java
+++ b/src/main/java/br/jus/trf2/assijus/AssijusServlet.java
@@ -34,9 +34,9 @@ public class AssijusServlet extends SwaggerServlet {
 		addRestrictedProperty("blucservice.url", "http://localhost:8080/blucservice/api/v1");
 		addPublicProperty("siga.url", "http://siga.jfrj.jus.br");
 		addPublicProperty("dotnet.download.url", "http://assijus.jfrj.jus.br/downloads/Microsoft-DOT-NET-Framework-x86-x64-AllOS-ENU.exe");
-		addPublicProperty("java8.download.url", "resources/download/jre-8u301-macosx-x64.dmg");
+		addPublicProperty("java8.download.url", "resources/download/jdk-8u301-macosx-x64.dmg");
 		addPublicProperty("exibe.titulo.dr", "true");
-		addPublicProperty("extensao.macos.version", "2.0.0");
+		addPublicProperty("extensao.macos.version", "2.0.1");
 		addPublicProperty("extensao.windows.version", "1.2.10.6");
 		
 		// Redis

--- a/src/main/webapp/popup.html
+++ b/src/main/webapp/popup.html
@@ -196,6 +196,9 @@
 							<u>Tutorial de Instalação</u>
 						</a>para preparar seu computador para assinatura.
 					</p>
+					<p>Em dispositivos móveis, baixe e utilize apenas a  
+						<a href="#/instalacao#mobile" target="_BLANK"><u>Versão mobile</u></a>.
+					</p>
 				</div>
 
 				<div class="alert alert-danger"

--- a/src/main/webapp/resources/app.js
+++ b/src/main/webapp/resources/app.js
@@ -907,15 +907,19 @@ app
 			// Initialize
 			//
 			$scope.getAuthKey = function() {
-				return $scope.authkey;
+				return sessionStorage.getItem(window.location.host +'-assijus-authkey');
 			}
 
 			$scope.setAuthKey = function(authkey) {
-				$scope.authkey = authkey;
+				sessionStorage.setItem(window.location.host +'-assijus-authkey', authkey);
+			}
+			
+			$scope.removeAuthKey = function() {
+				sessionStorage.removeItem(window.location.host +'-assijus-authkey');
 			}
 
 			$scope.hasAuthKey = function() {
-				return $scope.hasOwnProperty('authkey');
+				return $scope.getAuthKey() != null;  
 			}
 
 			// 2 steps
@@ -1137,7 +1141,7 @@ app
 					delete $scope.keystore;
 					delete $scope.userSubject;
 					delete $scope.userPIN;
-					delete $scope.authkey;
+					$scope.removeAuthKey();
 					$scope.forceRefresh();
 					console.log(response.data.errormsg);
 				}, function errorCallback(response) {

--- a/src/main/webapp/resources/home.html
+++ b/src/main/webapp/resources/home.html
@@ -77,6 +77,9 @@
 								de Instalação</u>
 						</a>para preparar seu computador para assinatura.
 					</p>
+					<p>Em dispositivos móveis, baixe e utilize apenas a  
+						<a href="#/instalacao#mobile"><u>Versão mobile</u></a>.
+					</p>
 				</div>
 
 				<div class="alert alert-danger"

--- a/src/main/webapp/resources/home.html
+++ b/src/main/webapp/resources/home.html
@@ -114,7 +114,12 @@
 				<p style="font-size: 120%;">
 					<span ng-show="apresentarTitulo()">Dr(a).</span> {{assinante}}, não
 					localizamos nenhum documento pendente de assinatura.
+					<span><button id="selCertificate" ng-show="permiteLogout()"
+						class="btn btn-light ml-1" ng-click="logout(progress)"
+						title="Clique para selecionar outro certificado">&#9167;
+					</button></span>
 				</p>
+
 			</div>
 		</div>
 

--- a/src/main/webapp/resources/instalacao.html
+++ b/src/main/webapp/resources/instalacao.html
@@ -40,7 +40,7 @@
 				<p class="lead">
 					O Assijus Web é compatível apenas com o navegador <strong>Google
 						Chrome</strong>, através da instalação de uma Chrome Extension. Para
-					dispositivos móveis utilize a <a href="#/instalacao#mobile"><u>Versão
+					dispositivos móveis baixe e <strong>utilize apenas</strong> <a href="#/instalacao#mobile"><u>Versão
 							mobile</u></a>
 				</p>
 				<!-- <a class="btn btn-lg btn-primary" href="#" role="button">Leia

--- a/src/main/webapp/resources/popup-app.js
+++ b/src/main/webapp/resources/popup-app.js
@@ -766,15 +766,6 @@ app
 					cn = cn.replace("CN=", "");
 				}
 				$scope.assinante = cn;
-
-				if (window.wootric !== undefined) {
-					window.wootricSettings = {
-						email: cn,
-						created_at: 1234567890,
-						account_token: 'NPS-0f40366d'
-					};
-					window.wootric('run');
-				}
 			}
 
 			function isPkcsEnabled(keystoreSupported) {

--- a/src/main/webapp/resources/popup-app.js
+++ b/src/main/webapp/resources/popup-app.js
@@ -476,15 +476,15 @@ app
 			// Initialize
 			//
 			$scope.getAuthKey = function() {
-				return $scope.authkey;
+				return sessionStorage.getItem(window.location.host +'-assijus-authkey');
 			}
 
 			$scope.setAuthKey = function(authkey) {
-				$scope.authkey = authkey;
+				sessionStorage.setItem(window.location.host +'-assijus-authkey', authkey);
 			}
 
 			$scope.hasAuthKey = function() {
-				return $scope.hasOwnProperty('authkey');
+				return $scope.getAuthKey() != null;  
 			}
 
 			// 2 steps


### PR DESCRIPTION
- Passando o AuthKey para o SessionStorage para manter autenticação em caso de reload da página
- Adicionado Eject Cert para bloco sem lista de documentos
- Correção do Native Client. Substituição do Base64Coder para Base64 do Java Utils
- Adicionado Link para download da JDK que para Mac OS 10.X é pré requisito para instanciar o Native Cliente via linha de comando Java