### PR TITLE
Correção URL de visualização documento

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2</groupId>
 	<artifactId>assijus</artifactId>
 	<packaging>war</packaging>
-	<version>4.1.1</version>
+	<version>4.1.2</version>
 	<name>Assijus Maven Webapp</name>
 	<url>http://maven.apache.org</url>
 

--- a/src/main/webapp/resources/home.html
+++ b/src/main/webapp/resources/home.html
@@ -200,7 +200,7 @@
 								name="ad_url_post_password_{{doc.id}}" value="{{doc.code}}" />
 							</td>
 							<td><a
-								href="/assijus/api/v1/view/{{doc.system}}/{{doc.id}}/{{doc.secret}}/{{authkey}}"
+								href="/assijus/api/v1/view/{{doc.system}}/{{doc.id}}/{{doc.secret}}/{{getAuthKey()}}"
 								target="_blank">{{doc.code}}</a></td>
 							<td>{{doc.descr}}</td>
 							<td>{{doc.kind}}</td>


### PR DESCRIPTION
Devido a troca do $scope.authKey para o session storage, nesse html havia a chamada sem o getter.