### PR TITLE
GOVSP: Passagem de parâmetro opcional da URL popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ A maneira mais simples de integrar um novo sistema ao Assijus é utilizando uma 
 produzirAssinaturaDigital({
 		ui: 'bootstrap-3',
 		
+		// url do popup que será injetado no iframe. Se não informado, segue o default do <assijus-url> no maven
+		iframePopupUrl: 'https://assijus.trf2.jus.br/assijus/popup.html',
+		
 		docs: [
 			{id: 1, code: 'TRF-MEM-2017/00001'},
 			{id: 2, code: 'TRF-MEM-2017/00002'}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2</groupId>
 	<artifactId>assijus</artifactId>
 	<packaging>war</packaging>
-	<version>4.1.3</version>
+	<version>4.1.4</version>
 	<name>Assijus Maven Webapp</name>
 	<url>http://maven.apache.org</url>
 

--- a/src/main/webapp/popup-api.js
+++ b/src/main/webapp/popup-api.js
@@ -55,6 +55,10 @@ function receiveMessageAssinaturaDigital(event) {
 var produzirAssinaturaDigital = function(params) {
 	window._AssinaturaDigitalParametros = params;
 	window.addEventListener("message", receiveMessageAssinaturaDigital, false);
+	
+	if (params.iframePopupUrl !== undefined && params.iframePopupUrl !== '') {
+		frameSrc = params.iframePopupUrl;
+	}
 
 	if (!params.beginCallback)
 		params.beginCallback = function() {


### PR DESCRIPTION
Para evitar que o assijus seja buildado para cada ambiente a fim de trocar a URL do popup, foi implementado o recebimento do parametro que se definido na origem, troca a URL do popup para injetar o popup do ambiente corretamente.

Caso, não seja definido o parâmetro, assijus segue o default que é obter a URL do popup do assijus-url no build do maven, como default o assijus do TRF2.